### PR TITLE
Add initial ´nx.json´ file

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,20 @@
+{
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "nx/tasks-runners/default",
+    }
+  },
+  "targetDefaults": {
+    "build": {
+      "dependsOn": [
+        "^build"
+      ]
+    },
+    "dev": {
+      "dependsOn": [
+        "^build"
+      ]
+    }
+
+  }
+}


### PR DESCRIPTION
As the `yarn start` script utilizes `run-p` to run `build:dev` and `dev` in parallel, `alma-web`'s `dev` script appears to execute before the `alma-webgl` package has built. 

This PR declares script dependency (via `nx.json`), to ensure that the `dev` script isn't executed before `build` script has finished.

Fixes #65